### PR TITLE
fix: use correct delegateName config option

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ const main = async (data) => {
                 transaction.signatureAsset(secondPassphrase);
 
             } else if (type === Enums.TransactionType.DelegateRegistration) {
-                const username = config.delegate || `delegate.${senderKeys.publicKey.slice(0, 10)}`;
+                const username = config.delegateName || `delegate.${senderKeys.publicKey.slice(0, 10)}`;
                 transaction.usernameAsset(username);
 
             } else if (type === Enums.TransactionType.Vote) {


### PR DESCRIPTION
Config used `delegateName` while script looked for `config.delegate` so it didn't pick up on the correct name to use.