### PR TITLE
refactor: add networkTime to expiration.value only once

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,8 +324,10 @@ const main = async (data) => {
                 transaction.amount(config.amount);
 
                 if (config.htlc.lock.expiration.type === Enums.HtlcLockExpirationType.EpochTimestamp) {
-                    const networktime =  await retrieveNetworktime();
-                    config.htlc.lock.expiration.value += networktime;
+                    const networktime = await retrieveNetworktime();
+                    if (config.htlc.lock.expiration.value < networktime) {
+                        config.htlc.lock.expiration.value += networktime;
+                    }
                 }
 
                 transaction.htlcLockAsset(config.htlc.lock);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

When sending multiple HTLC locks at once (e.g. `Ѧ 8 5`) the `networkTime` value would be added multiple times to the expiration value of the lock.

With this change, the `networkTime` is added only once, as to not accidentally create locks that won't expire in a reasonable amount of time.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
